### PR TITLE
Markdown support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+makem.sh linguist-vendored

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,12 @@ jobs:
 
     - name: Initialize Sandbox
       run: |
-        ./makem.sh -vv --sandbox $SANDBOX_DIR --install-deps --install-linters
+        make sandbox
 
     - name: Test
       if: always()  # Run test even if linting fails.
-      run: ./makem.sh -vv --sandbox $SANDBOX_DIR --exclude orb-helm.el --exclude orb-ivy.el test
+      run: |
+        make test
 
 # Local Variables:
 # eval: (outline-minor-mode)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Create Sandbox Directory
       run: |
-        SANDBOX_DIR=$(mktemp -d) || exit 1
+        SANDBOX_DIR=$(mktemp -d --dry-run) || exit 1
         echo "SANDBOX_DIR=$SANDBOX_DIR" >> $GITHUB_ENV
 
     - name: Initialize Sandbox

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -26,3 +26,4 @@ I want the version to be bigger than 1.2.4 so that it never looks like a downgra
 - Support plain strings in =ROAM_KEY= like ~#+roam_key: miman2017~
 - Slug styles are defined in =kisaragi-notes/slug-replacements= now
 - Replace =org-protocol://roam-ref= and =org-protocol://roam-file= handlers with =org-protocol://notes=, which supports =file= and =key= arguments
+- Tag sources is now specified as a list of extraction functions and not as symbols.

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -27,3 +27,7 @@ I want the version to be bigger than 1.2.4 so that it never looks like a downgra
 - Slug styles are defined in =kisaragi-notes/slug-replacements= now
 - Replace =org-protocol://roam-ref= and =org-protocol://roam-file= handlers with =org-protocol://notes=, which supports =file= and =key= arguments
 - Tag sources is now specified as a list of extraction functions and not as symbols.
+- Hugo's =#+tags[]= property is also used as a tag source.
+- Markdown support, effectively including the functionalities of md-roam
+  - Links are expected to be ordinary inline links
+  - Wiki links (=[[path]]=) are not yet supported

--- a/Makefile
+++ b/Makefile
@@ -1,70 +1,12 @@
-# * makem.sh/Makefile --- Script to aid building and testing Emacs Lisp packages
+SANDBOX_DIR ?= .sandbox
 
-# This Makefile is from the makem.sh repo: <https://github.com/alphapapa/makem.sh>.
+$(SANDBOX_DIR):
+	mkdir $(SANDBOX_DIR)
+	./makem.sh -vv --sandbox=$(SANDBOX_DIR) --install-deps --install-linters
 
-# * Arguments
+sandbox: $(SANDBOX_DIR)
 
-# For consistency, we use only var=val options, not hyphen-prefixed options.
+test: $(SANDBOX_DIR)
+	./makem.sh -vv --sandbox=$(SANDBOX_DIR) --exclude orb-helm.el --exclude orb-ivy.el test
 
-# NOTE: I don't like duplicating the arguments here and in makem.sh,
-# but I haven't been able to find a way to pass arguments which
-# conflict with Make's own arguments through Make to the script.
-# Using -- doesn't seem to do it.
-
-ifdef install-deps
-	INSTALL_DEPS = "--install-deps"
-endif
-ifdef install-linters
-	INSTALL_LINTERS = "--install-linters"
-endif
-
-ifdef sandbox
-	ifeq ($(sandbox), t)
-		SANDBOX = --sandbox
-	else
-		SANDBOX = --sandbox $(sandbox)
-	endif
-endif
-
-ifdef debug
-	DEBUG = "--debug"
-endif
-
-# ** Verbosity
-
-# Since the "-v" in "make -v" gets intercepted by Make itself, we have
-# to use a variable.
-
-verbose = $(v)
-
-ifneq (,$(findstring vv,$(verbose)))
-	VERBOSE = "-vv"
-else ifneq (,$(findstring v,$(verbose)))
-	VERBOSE = "-v"
-endif
-
-# * Rules
-
-# TODO: Handle cases in which "test" or "tests" are called and a
-# directory by that name exists, which can confuse Make.
-
-%:
-	@./makem.sh $(DEBUG) $(VERBOSE) $(SANDBOX) $(INSTALL_DEPS) $(INSTALL_LINTERS) $(@)
-
-.DEFAULT: init
-init:
-	@./makem.sh $(DEBUG) $(VERBOSE) $(SANDBOX) $(INSTALL_DEPS) $(INSTALL_LINTERS)
-
-docs:
-	@$(MAKE) -C doc all
-
-html:
-	@$(MAKE) -C doc html-dir
-
-install: install-docs
-
-install-docs: docs
-	@$(MAKE) -C doc install-docs
-
-install-info: info
-	@$(MAKE) -C doc install-info
+.PHONY: test sandbox

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -504,6 +504,8 @@ additional extraction methods, see [[id:c986edba-9498-4af1-b033-c94b733d42c8][Cu
 :ID:       c986edba-9498-4af1-b033-c94b733d42c8
 :END:
 
+TODO: replaced with =kisaragi-notes/tag-sources=, which is now a just a list of functions.
+
 Org-roam calls ~org-roam--extract-tags~ to extract tags from files. The variable
 ~org-roam-tag-sources~, to control how tags are extracted.
 

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -373,11 +373,11 @@ time by setting ~org-roam-db-update-idle-seconds~; or change the cache update
 to be triggered immediately after buffer save by setting
 ~org-roam-db-update-method~ to ~'immediate~.
 
-For experienced ~org-capture~ users, the behavior of ~M-x org-roam-find-file~ 
-may seem unfamiliar: after finishing a capture with ~C-c C-c~, you are returned  
-not to the original buffer from which you called ~M-x org-roam-find-file~, but 
-to a buffer pointing to the note you just created. For the usual ~org-capture~ 
-behavior you can call ~M-x org-roam-capture~ instead of ~M-x org-roam-find-file~. 
+For experienced ~org-capture~ users, the behavior of ~M-x org-roam-find-file~
+may seem unfamiliar: after finishing a capture with ~C-c C-c~, you are returned
+not to the original buffer from which you called ~M-x org-roam-find-file~, but
+to a buffer pointing to the note you just created. For the usual ~org-capture~
+behavior you can call ~M-x org-roam-capture~ instead of ~M-x org-roam-find-file~.
 
 Org-roam makes it easy to create notes, and link them together. To link notes
 together, we call ~M-x org-roam-insert~. This brings up a prompt with a list of
@@ -540,7 +540,7 @@ methods:
     Extract the first directory relative to ~org-roam-directory~.
     That is, if a file is located at relative path foo/bar/file.org,
     the file will have tag "foo"
-    
+
 By default, only the ~'prop~ extraction method is enabled. To enable the other
 extraction methods, you may modify ~org-roam-tag-sources~, for example:
 
@@ -741,7 +741,7 @@ The Org-roam buffer displays backlinks for the currently active Org-roam note.
   ~delete-other-windows~, by setting it with the following:
 
   ~(setq org-roam-buffer-window-parameters '((no-delete-other-windows . t)))~
-  
+
 ** Org-roam Files
 
 Org-roam files are created and prefilled using Org-roam's templating
@@ -960,10 +960,10 @@ The entry point to graph creation is ~org-roam-graph~.
   2. a function accepting a single argument: the graph file path.
 
   ~nil~ uses ~view-file~ to view the graph.
-  
+
   If you are using WSL2 and would like to open the graph in Windows, you can use
   the second option to set the browser and network file path:
-  
+
   #+BEGIN_SRC emacs-lisp
   (setq org-roam-graph-viewer
       (lambda (file)
@@ -1269,7 +1269,7 @@ specifying the outline-path to a heading:
 #+end_src
 
 The template ~l~ will put its notes under the heading ‘Lab notes’, and the
-template ~j~ will put its notes under the heading ‘Journal’. 
+template ~j~ will put its notes under the heading ‘Journal’.
 
 ** Capturing and finding daily-notes
 
@@ -1302,7 +1302,7 @@ There are also commands which allow you to use Emacs’s ~calendar~ to find the 
   Create an entry in the daily note for a date using the calendar.
 
   Prefer past dates, unless ~prefer-future~ is non-nil.
-  
+
   With a 'C-u' prefix or when ~goto~ is non-nil, go the note without
   creating an entry.
 
@@ -1313,7 +1313,7 @@ There are also commands which allow you to use Emacs’s ~calendar~ to find the 
   Prefer past dates, unless ~prefer-future~ is non-nil.
 
 ** Navigation
-  
+
 You can navigate between daily-notes:
 
 - Function: ~org-roam-dailies-find-directory~
@@ -1681,7 +1681,7 @@ are the solutions:
 [fn:1] Depending on your completion framework, you may need to press TAB to
 see the list.
 [fn:roam] To understand more about Roam, a collection of links are available in [[*Note-taking Workflows][Note-taking Workflows]].
- 
+
 # Local Variables:
 # eval: (require 'ol-info)
 # eval: (require 'ox-texinfo+ nil t)

--- a/kisaragi-notes-vars.el
+++ b/kisaragi-notes-vars.el
@@ -38,6 +38,7 @@ Currently available sources:
     Extract the first directory relative to `org-roam-directory'.
     That is, if a file is located at relative path foo/bar/file.org,
     the file will have tag \"foo\"."
+  :group 'org-roam
   :type '(set (const :tag "#+roam_tags"
                      org-roam--extract-tags-prop)
               (const :tag "buffer org tags"

--- a/kisaragi-notes-vars.el
+++ b/kisaragi-notes-vars.el
@@ -1,0 +1,66 @@
+;;; kisaragi-notes-vars.el --- Variable declarations -*- lexical-binding: t -*-
+
+;;; Commentary:
+
+;; Variable declarations intended to make extra `defvar's unnecessary.
+
+;;; Code:
+
+(defcustom kisaragi-notes/tag-sources
+  '(org-roam--extract-tags-prop)
+  "Sources to obtain tags from.
+
+This should be a list of functions that will extract tags from a buffer.
+
+Currently available sources:
+
+  `org-roam--extract-tags-prop'
+    Extract tags from the #+roam_tags property.
+    Tags are space delimited.
+    Tags may contain spaces if they are double-quoted.
+    e.g. #+roam_tags: TAG \"tag with spaces\"
+
+  `org-roam--extract-tags-vanilla'
+    Extract vanilla `org-mode' tags, including #+FILETAGS and
+    inherited tags.
+
+  `org-roam--extract-tags-all-directories'
+    Extract sub-directories relative to `org-roam-directory'.
+    That is, if a file is located at relative path foo/bar/file.org,
+    the file will have tags \"foo\" and \"bar\".
+
+  `org-roam--extract-tags-last-directory'
+    Extract the last directory relative to `org-roam-directory'.
+    That is, if a file is located at relative path foo/bar/file.org,
+    the file will have tag \"bar\".
+
+  `org-roam--extract-tags-first-directory'
+    Extract the first directory relative to `org-roam-directory'.
+    That is, if a file is located at relative path foo/bar/file.org,
+    the file will have tag \"foo\"."
+  :type '(set (const :tag "#+roam_tags"
+                     org-roam--extract-tags-prop)
+              (const :tag "buffer org tags"
+                     org-roam--extract-tags-vanilla)
+              (const :tag "sub-directories"
+                     org-roam--extract-tags-all-directories)
+              (const :tag "parent directory"
+                     org-roam--extract-tags-last-directory)
+              (const :tag "first sub-directory"
+                     org-roam--extract-tags-first-directory)))
+
+(defcustom org-roam-tag-sort nil
+  "When non-nil, sort tags in completions.
+
+When t, sort the tags alphabetically, regardless of case.
+
+This can also be a list like '(string-less-p :key downcase), in
+which case the list is passed to `cl-sort' as arguments."
+  :type '(choice
+          (boolean)
+          (list :tag "Arguments to cl-loop"))
+  :group 'org-roam)
+
+(provide 'kisaragi-notes-vars)
+
+;;; kisaragi-notes-vars.el ends here

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -1150,7 +1150,7 @@ modified, there is a number of prefined extra actions
 user actions can be set in `orb-note-actions-user'."
   (interactive)
   (let ((non-default-interfaces (list 'hydra 'ido 'ivy 'helm))
-        (citekey (cdar (org-roam--extract-refs))))
+        (citekey (cdar (kisaragi-notes-extract/refs))))
     (if citekey
         (cond ((member orb-note-actions-interface non-default-interfaces)
                (orb-note-actions--run orb-note-actions-interface citekey))

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -514,10 +514,10 @@ symbols is implied."
   (let* ((targets (--> (if (and targets (not (listp targets)))
                            (listp targets)
                          targets)
-                       ;; filter irrelevant symbols,
-                       ;; or if targets were nil, make all targets
-                       (or (-intersection it '(prepare before after))
-                           '(prepare before after)))))
+                    ;; filter irrelevant symbols,
+                    ;; or if targets were nil, make all targets
+                    (or (-intersection it '(prepare before after))
+                        '(prepare before after)))))
     (dolist (target targets)
       (let ((functions (sort (orb-plist-get
                               (intern (format ":%s-functions" target)))
@@ -787,8 +787,8 @@ before calling any Org-roam functions."
   (when orb-switch-persp
     (orb--switch-perspective))
   (let ((note-data (orb-note-exists-p citekey)))
-      ;; Find org-roam reference with the CITEKEY and collect data into
-      ;; `orb-plist'
+    ;; Find org-roam reference with the CITEKEY and collect data into
+    ;; `orb-plist'
     (orb-plist-put :note-existed (and note-data t))
     (cond
      (note-data
@@ -922,8 +922,8 @@ If ARG is non-nil, rebuild `bibtex-completion-cache'."
          (citekey (if (eq orb-insert-generic-candidates-format 'key)
                       selection
                     (--> (alist-get selection candidates nil nil #'equal)
-                         (cdr it)
-                         (alist-get "=key=" it  nil nil #'equal)))))
+                      (cdr it)
+                      (alist-get "=key=" it  nil nil #'equal)))))
     (orb-insert-edit-notes (list citekey))))
 
 (defun orb-insert-edit-notes (citekey)

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -194,7 +194,7 @@ or to this file's ROAM_KEY.
                 (titles-and-refs
                  (with-current-buffer org-roam-buffer--current
                    (cons (org-roam--extract-titles)
-                         (org-roam--extract-refs))))
+                         (kisaragi-notes-extract/refs))))
                 (backlinks
                  (if cite?
                      (mapcan #'org-roam--get-backlinks

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -48,7 +48,7 @@
 
 (defvar org-agenda-files)
 (declare-function org-roam--extract-titles                 "org-roam-extract")
-(declare-function org-roam--extract-refs                   "org-roam-extract")
+(declare-function kisaragi-notes-extract/refs              "org-roam-extract")
 (declare-function org-roam--extract-tags                   "org-roam-extract")
 (declare-function org-roam--extract-ids                    "org-roam-extract")
 (declare-function org-roam--extract-links                  "org-roam-extract")
@@ -310,7 +310,7 @@ If UPDATE-P is non-nil, first remove the ref for the file in the database."
       (org-roam-db-query [:delete :from refs
                           :where (= file $s1)]
                          file))
-    (when-let ((refs (org-roam--extract-refs)))
+    (when-let ((refs (kisaragi-notes-extract/refs)))
       (dolist (ref refs)
         (let ((key (cdr ref))
               (type (car ref)))

--- a/org-roam-extract.el
+++ b/org-roam-extract.el
@@ -289,7 +289,25 @@ Reads from the \"roam_alias\" property."
   "Extract the first headline as a title in Markdown mode."
   (save-excursion
     (goto-char (point-min))
-    (when (re-search-forward md-roam-regex-headline nil t 1)
+    (when (re-search-forward
+           ;; Converted from md-roam's `md-roam-regex-headline'
+           (rx (or
+                ;; Case 1:
+                ;;
+                ;; foo-bar    or    foo-bar
+                ;; =======          -------
+                ;;
+                ;; Ensure the line before the heading text consists of
+                ;; only whitespaces to exclude front matter openers
+                ;; (md-roam uses "\s" which actually stands for a
+                ;; space; I'm guessing that's a mistake)
+                (seq bol (zero-or-more whitespace) "\n"
+                     (group (zero-or-more nonl) eol) "\n"
+                     (group bol (one-or-more (any "=-")) eol))
+                ;; Case 2: "# Heading" style
+                (seq (group bol (one-or-more "#") " ")
+                     (group (zero-or-more nonl) eol))))
+           nil t)
       (list (or (match-string-no-properties 1)
                 (match-string-no-properties 4))))))
 

--- a/org-roam-extract.el
+++ b/org-roam-extract.el
@@ -334,9 +334,15 @@ tag."
     (list (car (f-split dir-relative)))))
 
 (defun org-roam--extract-tags-prop (_file)
-  "Extract tags from the current buffer's \"#roam_tags\" global property."
+  "Extract tags from the current buffer's \"#+roam_tags\" global property.
+
+This also extracts from the #+tags[] property, which is what Hugo expects."
   (condition-case nil
-      (org-roam--extract-prop-as-list "ROAM_TAGS")
+      (append (org-roam--extract-prop-as-list "ROAM_TAGS")
+              ;; Extracting hugo style #+tags[].
+              ;; Concept from http://www.sidpatil.com/posts/org-roam-and-hugo-tags/
+              ;; (The fact that you simply need to change the prop it uses.)
+              (org-roam--extract-prop-as-list "TAGS[]"))
     (error
      (progn
        (lwarn '(org-roam) :error

--- a/org-roam-extract.el
+++ b/org-roam-extract.el
@@ -190,7 +190,9 @@ Assume links come from FILE-PATH."
   (save-excursion
     (goto-char (point-min))
     (cl-loop while (re-search-forward
-                    "\\(?:[^[:alnum:]]\\|^\\)\\(-?@\\)\\([-a-zA-Z0-9_+:]+\\)"
+                    (rx (or (not alnum) bol)
+                        (group (opt "-") "@")
+                        (group (one-or-more (any alnum "+:_-"))))
                     nil t)
              collect
              (let* ((target (match-string-no-properties 2))

--- a/org-roam-extract.el
+++ b/org-roam-extract.el
@@ -148,6 +148,7 @@ Assume links come from FILE-PATH."
                        "file" ; link-type
                        (list :content content :point begin-of-block))))))
 
+;; Modified from md-roam's `md-roam--extract-file-links'
 (defun org-roam--extract-links-markdown (file-path)
   "Extract Markdown links from current buffer.
 
@@ -181,6 +182,7 @@ Links are assumed to originate from FILE-PATH."
                  link-type
                  (list :content content :point begin-of-block)))))))
 
+;; Modified from md-roam's `md-roam--extract-cite-links'
 (defun org-roam--extract-links-pandoc-cite (file-path)
   "Extract cite links defined like this: @bibkey.
 
@@ -191,7 +193,7 @@ Assume links come from FILE-PATH."
                     "\\(?:[^[:alnum:]]\\|^\\)\\(-?@\\)\\([-a-zA-Z0-9_+:]+\\)"
                     nil t)
              collect
-             (let* ((to-file (match-string-no-properties 2))
+             (let* ((target (match-string-no-properties 2))
                     begin-of-block
                     end-of-block
                     content
@@ -203,7 +205,7 @@ Assume links come from FILE-PATH."
                  (setq begin-of-block (point))
                  (setq content (buffer-substring-no-properties begin-of-block end-of-block)))
                (vector file-path ; file-from
-                       to-file
+                       target
                        link-type
                        (list :content content :point begin-of-block))))))
 

--- a/org-roam-extract.el
+++ b/org-roam-extract.el
@@ -231,17 +231,17 @@ it as FILE-PATH."
 If FILE-PATH is nil, use the current file."
   (setq file-path (or file-path org-roam-file-name (buffer-file-name)))
   (let (result)
-      ;; We need to handle the special case of the file property drawer (at outline level 0)
-      (org-with-point-at (point-min)
-        (when-let ((before-first-heading (= 0 (org-outline-level)))
-                   (id (org-entry-get nil "ID")))
-           (push (vector id file-path 0) result)))
-      (org-map-region
-       (lambda ()
-         (when-let ((id (org-entry-get nil "ID")))
-           (push (vector id file-path (org-outline-level)) result)))
-       (point-min) (point-max))
-      result))
+    ;; We need to handle the special case of the file property drawer (at outline level 0)
+    (org-with-point-at (point-min)
+      (when-let ((before-first-heading (= 0 (org-outline-level)))
+                 (id (org-entry-get nil "ID")))
+        (push (vector id file-path 0) result)))
+    (org-map-region
+     (lambda ()
+       (when-let ((id (org-entry-get nil "ID")))
+         (push (vector id file-path (org-outline-level)) result)))
+     (point-min) (point-max))
+    result))
 
 (defun org-roam--extract-titles-title ()
   "Return title from \"#+title\" of the current buffer."
@@ -391,12 +391,12 @@ Each ref is returned as a cons of its type and its key."
         (`(,_ . ,roam-key)
          (org-roam--extract-global-props '("ROAM_KEY")))
       (pcase roam-key
-          ('nil nil)
-          ((pred string-empty-p)
-           (user-error "Org property #+roam_key cannot be empty"))
-          (ref
-           (when-let ((r (kisaragi-notes-extract//process-ref ref)))
-             (push r refs)))))
+        ('nil nil)
+        ((pred string-empty-p)
+         (user-error "Org property #+roam_key cannot be empty"))
+        (ref
+         (when-let ((r (kisaragi-notes-extract//process-ref ref)))
+           (push r refs)))))
     refs))
 
 (provide 'org-roam-extract)

--- a/org-roam-extract.el
+++ b/org-roam-extract.el
@@ -72,7 +72,7 @@ roam_alias."
       (format "#+begin_quote\n%s\n#+end_quote"
               (s-trim content)))
      (t
-      content))))
+      (s-trim content)))))
 
 (defun org-roam--extract-links-org (file-path)
   "Extract links in current buffer in Org mode format ([[target][desc]]).
@@ -234,6 +234,8 @@ it as FILE-PATH."
      ;; with wiki links, however, that's simply not the case.
      ;;
      ;; (org-roam--extract-links-wiki file-path)
+
+     ;; I won't bother to support Org links in Markdown.
      (org-roam--extract-links-markdown file-path)
      (org-roam--extract-links-pandoc-cite file-path)))))
 

--- a/org-roam-extract.el
+++ b/org-roam-extract.el
@@ -280,8 +280,21 @@ Reads from the \"roam_alias\" property."
                   (buffer-file-name)))
        nil))))
 
-(defun org-roam--extract-titles-headline ()
-  "Return the first headline of the current buffer."
+(cl-defgeneric org-roam--extract-titles-headline ()
+  "Extract the first headline as the document title."
+  nil)
+
+;; Function body from md-roam's `org-roam--extract-titles-mdheadline'
+(cl-defmethod org-roam--extract-titles-headline (&context (major-mode markdown-mode))
+  "Extract the first headline as a title in Markdown mode."
+  (save-excursion
+    (goto-char (point-min))
+    (when (re-search-forward md-roam-regex-headline nil t 1)
+      (list (or (match-string-no-properties 1)
+                (match-string-no-properties 4))))))
+
+(cl-defmethod org-roam--extract-titles-headline (&context (major-mode org-mode))
+  "Extract the first headline as a title in Org mode."
   (let ((headline (save-excursion
                     (goto-char (point-min))
                     ;; "What happens if a heading star was quoted

--- a/org-roam.el
+++ b/org-roam.el
@@ -193,20 +193,21 @@ which will then be replaced with a single underscore (\"_\")."
 
 (defcustom org-roam-title-sources '((title headline) alias)
   "The list of sources from which to retrieve a note title.
-Each element in the list is either:
 
-1. a symbol -- this symbol corresponds to a title retrieval
-function, which returns the list of titles for the current buffer
-2. a list of symbols -- symbols in the list are treated as
-with (1).  The return value of this list is the first symbol in
-the list returning a non-nil value.
+Return values from each source, which are symbols corresponding
+to a title retrieval function, are concatenated into the final
+list of titles. A source can also be a list of sources --- in
+which case the first non-nil return value is used.
 
-The return results of the root list are concatenated.
+For example, the default setting ((title headline) alias)
+effectively stands for this:
 
-For example the setting: '((title headline) alias) means the following:
+    (append (or title headline)
+            alias)
 
-1. Return the 'title + 'alias, if the title of current buffer is non-empty;
-2. Or return 'headline + 'alias otherwise.
+So, when the title is not empty, 'title + 'alias will be
+returned; otherwise, 'headline + 'alias is the resulting list of
+titles.
 
 The currently supported symbols are:
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -490,6 +490,20 @@ plist containing the path and title for the file."
               (v (list :path file-path :title title)))
           (push (cons k v) completions))))))
 
+(defun kisaragi-notes//get-files (title)
+  "Return files matching TITLE in the DB."
+  (->> (org-roam-db-query
+        ;; Leaving the join syntax here so that it's easier to modify
+        ;; later to support retrieving filepaths with tags, ids, and refs
+        [:select [files:file] :from files
+         :left-join titles
+         :on (= titles:file files:file)
+         :where (= title $s0)]
+        title)
+    ;; The above returns ((path1) (path2) ...).
+    ;; Turn it into (path1 path2 ...).
+    (apply #'nconc)))
+
 (defun org-roam--get-index-path ()
   "Return the path to the index in `org-roam-directory'.
 The path to the index can be defined in `org-roam-index-file'.

--- a/org-roam.el
+++ b/org-roam.el
@@ -93,12 +93,13 @@ All Org files, at any level of nesting, are considered part of the Org-roam."
   :type 'boolean
   :group 'org-roam)
 
-(defcustom org-roam-file-extensions '("org")
-  "Detected file extensions to include in the Org-roam ecosystem.
+(defcustom org-roam-file-extensions '("org" "md")
+  "Only files with these extensions are indexed.
+
 The first item in the list is used as the default file extension.
-While the file extensions may be different, the file format needs
-to be an `org-mode' file, and it is the user's responsibility to
-ensure that."
+
+While the file extensions may be different, the only supported
+file formats are Org-mode and Markdown (partially)."
   :type '(repeat string)
   :group 'org-roam)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.2.3
-;; Package-Requires: ((emacs "27.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.2") (bibtex-completion "2.0.0"))
+;; Package-Requires: ((emacs "27.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.2") (bibtex-completion "2.0.0") (markdown-mode "2.4"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -458,7 +458,7 @@ In Markdown, TYPE has no effect."
      (if (functionp org-roam-link-title-format)
          (funcall org-roam-link-title-format description type)
        (format org-roam-link-title-format description))))
-   ((derived-mode 'markdown-mode)
+   ((derived-mode-p 'markdown-mode)
     (cond ((and (not description) target)
            (format "<%s>" target))
           ((not description)

--- a/org-roam.el
+++ b/org-roam.el
@@ -641,8 +641,7 @@ If BUFFER is not specified, use the current buffer."
   (let ((buffer (or buffer (current-buffer)))
         path)
     (with-current-buffer buffer
-      (and (derived-mode-p 'org-mode)
-           (setq path (buffer-file-name (buffer-base-buffer)))
+      (and (setq path (buffer-file-name (buffer-base-buffer)))
            (org-roam--org-roam-file-p path)))))
 
 (defun org-roam--get-roam-buffers ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -47,6 +47,8 @@
 (require 'seq)
 (eval-when-compile (require 'subr-x))
 
+(require 'kisaragi-notes-vars)
+
 ;;;; Features
 (require 'org-roam-macs)
 ;; These features should be able to be loaded order independently.
@@ -169,58 +171,9 @@ method symbol as a cons cell. For example: '(find (rg . \"/path/to/rg\"))."
   :group 'org-roam)
 
 (defcustom org-roam-tag-separator ","
-  "String to use to separate tags when `org-roam-tag-sources' is non-nil."
+  "String to use to separate tags when `kisaragi-notes/tag-sources' is non-nil."
   :type 'string
   :group 'org-roam)
-
-(defcustom org-roam-tag-sort nil
-  "When non-nil, sort the tags in the completions.
-When t, sort the tags alphabetically, regardless of case.
-`org-roam-tag-sort' can also be a list of arguments to be applied
-to `cl-sort'.  For example, these are the arguments used when
-`org-roam-tag-sort' is set to t:
-    \('string-lessp :key 'downcase)
-Only relevant when `org-roam-tag-sources' is non-nil."
-  :type '(choice
-          (boolean)
-          (list :tag "Arguments to cl-loop"))
-  :group 'org-roam)
-
-(defcustom org-roam-tag-sources '(prop)
-  "Sources to obtain tags from.
-
-It should be a list of symbols representing any of the following
-extraction methods:
-
-  `prop'
-    Extract tags from the #+roam_tags property.
-    Tags are space delimited.
-    Tags may contain spaces if they are double-quoted.
-    e.g. #+roam_tags: TAG \"tag with spaces\"
-
-  `vanilla'
-    Extract vanilla `org-mode' tags, including #+FILETAGS and
-    inherited tags.
-
-  `all-directories'
-    Extract sub-directories relative to `org-roam-directory'.
-    That is, if a file is located at relative path foo/bar/file.org,
-    the file will have tags \"foo\" and \"bar\".
-
-  `last-directory'
-    Extract the last directory relative to `org-roam-directory'.
-    That is, if a file is located at relative path foo/bar/file.org,
-    the file will have tag \"bar\".
-
-  `first-directory'
-    Extract the first directory relative to `org-roam-directory'.
-    That is, if a file is located at relative path foo/bar/file.org,
-    the file will have tag \"foo\"."
-  :type '(set (const :tag "#+roam_tags" prop)
-              (const :tag "buffer org tags" vanilla)
-              (const :tag "sub-directories" all-directories)
-              (const :tag "parent directory" last-directory)
-              (const :tag "first sub-directory" first-directory)))
 
 (defcustom kisaragi-notes/slug-replacements
   '(("[^[:alnum:][:digit:]]" . "_") ; convert anything not alphanumeric

--- a/tests/roam-files/baz.md
+++ b/tests/roam-files/baz.md
@@ -1,0 +1,5 @@
+# Baz
+
+This is an ordinary Markdown file. The title is defined using a heading.
+
+There is also a link to [Nested Bar](nested/bar.org).

--- a/tests/roam-files/baz.md
+++ b/tests/roam-files/baz.md
@@ -3,3 +3,7 @@
 This is an ordinary Markdown file. The title is defined using a heading.
 
 There is also a link to [Nested Bar](nested/bar.org).
+
+Here's a citation with CJK characters: @乙野四方字20180920
+
+And here's an ASCII citation: @quro2017

--- a/tests/roam-files/cite-ref.md
+++ b/tests/roam-files/cite-ref.md
@@ -1,0 +1,3 @@
+---
+roam_key: sumire2019
+---

--- a/tests/roam-files/foo.org
+++ b/tests/roam-files/foo.org
@@ -6,3 +6,5 @@ To make the tests more robust, here are some arbitrary links:
 
 - [[https:google.com][Google]]
 - [[mailto:foo@john.com][mail to foo]]
+
+Here's another link to [[file:baz.md][Baz]], which is a Markdown file.

--- a/tests/roam-files/front-matter/gray-matter-json.md
+++ b/tests/roam-files/front-matter/gray-matter-json.md
@@ -1,0 +1,3 @@
+---json
+{"title": "JSON front matter in gray-matter style", "tags": ["a", "b"]}
+---

--- a/tests/roam-files/front-matter/gray-matter-toml.md
+++ b/tests/roam-files/front-matter/gray-matter-toml.md
@@ -1,0 +1,5 @@
+---toml
+title = "TOML front matter delimited in the way gray-matter expects"
+description = "Front matter"
+categories = "front matter toml"
+---

--- a/tests/roam-files/front-matter/jekyll.md
+++ b/tests/roam-files/front-matter/jekyll.md
@@ -1,0 +1,7 @@
+---
+title: Jekyll style front matter
+tag: A single tag with spaces in it
+tags: multiple separated tags
+---
+
+[Jekyll differentiates between](https://jekyllrb.com/docs/posts/#tags-and-categories) a singular `tag` property, which is not split up into multiple tags, and a plural `tags` property, which gets split on spaces.

--- a/tests/roam-files/front-matter/json.md
+++ b/tests/roam-files/front-matter/json.md
@@ -1,0 +1,3 @@
+{"title": "JSON front matter", "tags": ["a", "b"]}
+
+[JSON front matter in Hugo](https://gohugo.io/content-management/front-matter) is not specially delimited: the JSON object has to be the first thing in the file, and has to have a newline following it, but no additional fences are required.

--- a/tests/roam-files/front-matter/toml.md
+++ b/tests/roam-files/front-matter/toml.md
@@ -1,0 +1,4 @@
++++
+title = "TOML front matter delimited for Hugo"
+tags = ["a", "b"]
++++

--- a/tests/roam-files/front-matter/yaml.md
+++ b/tests/roam-files/front-matter/yaml.md
@@ -1,0 +1,4 @@
+---
+title: YAML front matter
+tags: [tag1, tag2]
+---

--- a/tests/roam-files/front-matter/zettlr-yaml.md
+++ b/tests/roam-files/front-matter/zettlr-yaml.md
@@ -1,0 +1,9 @@
+---
+title: "Zettlr style YAML front matter"
+tags:
+  - Zettlr
+  - Markdown
+  - YAML
+...
+
+Zettlr's front matter is ended with three dots, not three dashes.

--- a/tests/roam-files/tags/hugo-style.org
+++ b/tests/roam-files/tags/hugo-style.org
@@ -1,0 +1,2 @@
+#+title: Hugo style prop tags
+#+tags[]: hello tag2 tag3

--- a/tests/roam-files/tags/tag.md
+++ b/tests/roam-files/tags/tag.md
@@ -1,0 +1,5 @@
+---
+tags: #abc, #def, #ghi
+---
+
+Tags not in frontmatter: #not-frontmatter-a #not-front-matter-b

--- a/tests/roam-files/titles/aliases.md
+++ b/tests/roam-files/titles/aliases.md
@@ -1,0 +1,3 @@
+---
+roam_alias: ["alias1", "alias2"]
+---

--- a/tests/roam-files/titles/headline.md
+++ b/tests/roam-files/titles/headline.md
@@ -1,0 +1,1 @@
+# Headline

--- a/tests/roam-files/titles/title.md
+++ b/tests/roam-files/titles/title.md
@@ -1,0 +1,3 @@
+---
+title: Title in Markdown
+---

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -350,6 +350,21 @@
             :to-equal
             '(headline "" "headline" 0))))
 
+(describe "Accessing the DB"
+  (before-all
+    (test-org-roam--init))
+
+  (after-all
+    (test-org-roam--teardown))
+
+  (it "Returns a file from its title"
+    (expect (kisaragi-notes//get-files "Foo")
+            :to-equal
+            (list (test-org-roam--abs-path "foo.org")))
+    (expect (kisaragi-notes//get-files "Deeply Nested File")
+            :to-equal
+            (list (test-org-roam--abs-path "nested/deeply/deeply_nested_file.org")))))
+
 ;;; Tests
 (xdescribe "org-roam-db-build-cache"
   (before-each

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -235,7 +235,7 @@
                 (--map (seq-take it 3)))
               :to-have-same-items-as
               `([,(test-org-roam--abs-path "baz.md")
-                 ,(test-org-roam--abs-path "bar.org")
+                 ,(test-org-roam--abs-path "nested/bar.org")
                  "file"]
                 [,(test-org-roam--abs-path "baz.md")
                  "乙野四方字20180920"

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -192,6 +192,10 @@
               :to-equal
               '("Headline"))
       (expect (test #'org-roam--extract-titles-headline
+                    "titles/headline.md")
+              :to-equal
+              '("Headline"))
+      (expect (test #'org-roam--extract-titles-headline
                     "titles/combination.org")
               :to-equal
               '("Headline")))

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -272,6 +272,11 @@
                     (buf (find-file-noselect fname)))
                (with-current-buffer buf
                  (funcall fn fname)))))
+    (it "extracts from #+tags[]"
+      (expect (test #'kisaragi-notes-extract/tags-zettlr-frontmatter
+                    "tags/hugo-style.org")
+              :to-equal
+              '("hello" "tag2" "tag3")))
     (it "extracts Zettlr style tags, but only from frontmatter"
       (expect (test #'kisaragi-notes-extract/tags-zettlr-frontmatter
                     "tags/tag.md")

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -231,10 +231,17 @@
     (it "extracts links from Markdown files"
       (expect (->> (test #'org-roam--extract-links
                          "baz.md")
-                (--map (seq-take it 2)))
+                (--map (seq-take it 3)))
               :to-have-same-items-as
               `([,(test-org-roam--abs-path "baz.md")
-                 ,(test-org-roam--abs-path "bar.org")])))
+                 ,(test-org-roam--abs-path "bar.org")
+                 "file"]
+                [,(test-org-roam--abs-path "baz.md")
+                 "乙野四方字20180920"
+                 "cite"]
+                [,(test-org-roam--abs-path "baz.md")
+                 "quro2017"
+                 "cite"])))
     (it "extracts links from Org files"
       (expect (->> (test #'org-roam--extract-links
                          "foo.org")

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -111,17 +111,21 @@
     ;; Enable "cite:" link parsing
     (org-link-set-parameters "cite")
     (it "extracts web keys"
-      (expect (test #'org-roam--extract-refs
+      (expect (test #'kisaragi-notes-extract/refs
                     "web_ref.org")
               :to-equal
               '(("website" . "//google.com/"))))
     (it "extracts cite keys"
-      (expect (test #'org-roam--extract-refs
+      (expect (test #'kisaragi-notes-extract/refs
                     "cite_ref.org")
               :to-equal
-              '(("cite" . "mitsuha2007"))))
+              '(("cite" . "mitsuha2007")))
+      (expect (test #'kisaragi-notes-extract/refs
+                    "cite-ref.md")
+              :to-equal
+              '(("cite" . "sumire2019"))))
     (it "extracts all keys"
-      (expect (test #'org-roam--extract-refs
+      (expect (test #'kisaragi-notes-extract/refs
                     "multiple-refs.org")
               :to-have-same-items-as
               '(("cite" . "orgroam2020")

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -41,7 +41,8 @@
 (defun test-org-roam--init ()
   "."
   (let ((original-dir test-org-roam-directory)
-        (new-dir (expand-file-name (make-temp-name "org-roam") temporary-file-directory)))
+        (new-dir (expand-file-name (make-temp-name "org-roam") temporary-file-directory))
+        (org-roam-verbose nil))
     (copy-directory original-dir new-dir)
     (setq org-roam-directory new-dir)
     (org-roam-mode +1)

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -273,7 +273,7 @@
                (with-current-buffer buf
                  (funcall fn fname)))))
     (it "extracts from #+tags[]"
-      (expect (test #'kisaragi-notes-extract/tags-zettlr-frontmatter
+      (expect (test #'org-roam--extract-tags-prop
                     "tags/hugo-style.org")
               :to-equal
               '("hello" "tag2" "tag3")))

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -229,6 +229,18 @@
                     (buf (find-file-noselect fname)))
                (with-current-buffer buf
                  (funcall fn fname)))))
+    (it "extracts Zettlr style tags, but only from frontmatter"
+      (expect (test #'kisaragi-notes-extract/tags-zettlr-frontmatter
+                    "tags/tag.md")
+              :to-equal
+              '("#abc" "#def" "#ghi")))
+
+    (it "extracts Zettlr style tags"
+      (expect (test #'kisaragi-notes-extract/tags-zettlr
+                    "tags/tag.md")
+              :to-equal
+              '("#abc" "#def" "#ghi" "#not-frontmatter-a" "#not-front-matter-b")))
+
     (it "extracts from prop"
       (expect (test #'org-roam--extract-tags-prop
                     "tags/tag.org")

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -152,6 +152,10 @@
               :to-equal
               '("Title"))
       (expect (test #'org-roam--extract-titles-title
+                    "titles/title.md")
+              :to-equal
+              '("Title in Markdown"))
+      (expect (test #'org-roam--extract-titles-title
                     "titles/aliases.org")
               :to-equal
               nil)

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -216,7 +216,7 @@
                 '("Headline" "roam" "alias" "TITLE PROP"))))))
 
 (describe "Tag extraction"
-  :var (org-roam-tag-sources)
+  :var (kisaragi-notes/tag-sources)
   (before-all
     (test-org-roam--init))
 
@@ -281,15 +281,16 @@
               :to-equal
               '("nested")))
 
-    (describe "uses org-roam-tag-sources correctly"
+    (describe "uses kisaragi-notes/tag-sources correctly"
       (it "'(prop)"
-        (expect (let ((org-roam-tag-sources '(prop)))
+        (expect (let ((kisaragi-notes/tag-sources '(org-roam--extract-tags-prop)))
                   (test #'org-roam--extract-tags
                         "tags/tag.org"))
                 :to-equal
                 '("t1" "t2 with space" "t3" "t4 second-line")))
       (it "'(prop all-directories)"
-        (expect (let ((org-roam-tag-sources '(prop all-directories)))
+        (expect (let ((kisaragi-notes/tag-sources '(org-roam--extract-tags-prop
+                                                    org-roam--extract-tags-all-directories)))
                   (test #'org-roam--extract-tags
                         "tags/tag.org"))
                 :to-equal


### PR DESCRIPTION
Merging md-roam's functionalities.

- [x] Title extraction
  - [x] org-roam--extract-titles-mdtitle
  - [x] org-roam--extract-titles-mdalias
  - [x] org-roam--extract-titles-mdheadline
- [x] md-roam--extract-ref
- [x] Changelog

Difference with md-roam: I'm not really bothering with wiki links. My version of `org-roam-format-link` inserts normal `[desc](url)` links.

I'd prefer if wiki links uses note titles and not filepaths, but to do that we must make sure titles are extracted and stored into the DB before links are extracted. I'm not yet doing it.